### PR TITLE
#164185755 Add get offices endpoint

### DIFF
--- a/src/http.ml
+++ b/src/http.ml
@@ -1,10 +1,25 @@
 type http
 
+module Request = struct
+    type t
+    external url : t -> string = "" [@@bs.get ]
+    external method_ : t -> string = "method" [@@bs.get ]
+    end
+
 module Response = struct
     type t
-    external end_ : string -> unit = "end" [@@bs.send.pipe :t] end
+    external end_ : 'a -> unit = "end" [@@bs.send.pipe :t]
+    external setHeader :  t -> string -> string -> unit = "" [@@bs.send ]
 
-external createServer : (string -> Response.t -> unit) -> http = "" [@@bs.module "http"]
+    let setHeader (header : string) (value : string) (response : t) =
+        setHeader response header value;
+        response
+
+    end
+
+
+external createServer : (Request.t -> Response.t -> unit) -> http = "" [@@bs.module "http"]
 
 external listen: int -> unit = "" [@@bs.send.pipe :http]
+
 

--- a/src/responses.ml
+++ b/src/responses.ml
@@ -1,0 +1,9 @@
+type office = {
+    name: string;
+    type_: string [@bs.as "type"]
+} [@@bs.deriving jsConverter]
+
+type offices = {
+    status: int;
+    data: office array
+} [@@bs.deriving jsConverter]

--- a/src/server.ml
+++ b/src/server.ml
@@ -1,8 +1,10 @@
 open Http
+open Views
 
-let _ = createServer (fun _req -> fun res -> (
-    Response.(
-        res |> end_ "Hello world"
-    )
+
+let _ = createServer (fun req -> fun res -> (
+    
+    views (req, res)
+    
 ))
 |> listen 3000

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -1,0 +1,1 @@
+external stringify: 'a -> string = "" [@@bs.val][@@bs.scope "JSON"]

--- a/src/views.ml
+++ b/src/views.ml
@@ -1,0 +1,16 @@
+open Http
+open Responses
+
+open Utils
+
+let views (req, res) = 
+    match(Request.url req) with
+    | "/offices" when (Request.method_ req) = "GET" -> Response.(
+         res
+         |> setHeader "Content-Type" "application/json"
+         |> end_ (stringify (officesToJs { status = 200; data= [||] }))
+    )
+    | route -> Response.(
+        res |> end_  route
+    )
+


### PR DESCRIPTION
**What does this PR do?**

This PR sets up the get all offices endpoint that can be accessed via `/offices`

**Description of Task to be completed?**

- [x] - Create new route to get all offices
- [x] - Create responses module for data types
- [x] - Abstract away views to switch routes

**How do I manually test this **
1. Clone this repo
2. Install dependencies
3. Run `npm build`
4. Run `node src/server.bs.js`
5. Open postman and navigate to `localhost:3000/offices`

**What are the relevant pivotal tracker stories?**
[#164185755](https://www.pivotaltracker.com/n/projects/2241721/stories/164185755)

**Screenshots**
![image](https://user-images.githubusercontent.com/12128153/53327297-92f3b200-38f8-11e9-9773-ba3dd177e71e.png)
