### PR TITLE
#164430474 Add id prop to office object

### DIFF
--- a/src/views.re
+++ b/src/views.re
@@ -20,7 +20,48 @@ let views = ((req, res)) =>
             _ =>
               switch (Js.Json.parseExn(data^)) {
               | value =>
-                offices := List.append([value], offices^);
+                let myMap = Js.Dict.empty();
+
+                switch (Js.Json.classify(value)) {
+                | Js.Json.JSONObject(a) =>
+                  switch (Js.Dict.get(a, "name")) {
+                  | Some(name) => Js.Dict.set(myMap, "name", name)
+                  | _ =>
+                    Response.(
+                      res
+                      |> jsonify(
+                           400,
+                           {"status": 400, "message": "Name is not provided"},
+                         )
+                    )
+                  };
+
+                  switch (Js.Dict.get(a, "type")) {
+                  | Some(type_) => Js.Dict.set(myMap, "type", type_)
+                  | _ =>
+                    Response.(
+                      res
+                      |> jsonify(
+                           400,
+                           {"status": 400, "message": "Type is not provided"},
+                         )
+                    )
+                  };
+                | _ =>
+                  Response.(
+                    res
+                    |> jsonify(
+                         400,
+                         {"status": 400, "message": "Not an object"},
+                       )
+                  )
+                };
+                Js.Dict.set(
+                  myMap,
+                  "id",
+                  Js.Json.number(float_of_int(List.length(offices^))),
+                );
+                offices := List.append([myMap], offices^);
                 Response.(
                   res
                   |> jsonify(
@@ -28,6 +69,7 @@ let views = ((req, res)) =>
                        {"status": 200, "message": "Data received"},
                      )
                 );
+
               | exception _ =>
                 Response.(
                   res


### PR DESCRIPTION
**What does this PR do?**
<!-- A short description of what the pull request does -->
This PR adds an ID Property to an office for easy identification

**Description of Task to be completed?**

<!-- Outline the tasks completed by the pr -->

- [x] Add id prop to an office before saving
it to office list


**Any background context you want to provide?**
The ID will be used to identify an office.

**What are the relevant pivotal tracker stories?**
[#164430474](https://www.pivotaltracker.com/n/projects/2241721/stories/164430474)

**Screenshots (if appropriate)**

![image](https://user-images.githubusercontent.com/12128153/53967309-0e7a0e00-4106-11e9-9272-a344d3f40f41.png)
