### PR TITLE
Match on the http methods

### DIFF
--- a/src/views.re
+++ b/src/views.re
@@ -2,40 +2,28 @@ open Http;
 
 let views = ((req, res)) => {
   let path = Request.url(req)->Utils.replacepath;
-  switch (path) {
-  | "offices" when Request.isMethod(req, "GET") =>
-    Offices.resolveAllOffices(res)
-  | "offices" when Request.isMethod(req, "POST") =>
-    Offices.createOffice(req, res)
-  | specificoffice
-      when
-        Request.isMethod(req, "GET")
-        && Utils.isRouteDynamic(specificoffice, "offices") =>
+  switch (path, Request.method(req)) {
+  | ("offices", "GET") => Offices.resolveAllOffices(res)
+  | ("offices", "POST") => Offices.createOffice(req, res)
+  | (specificoffice, "GET")
+      when Utils.isRouteDynamic(specificoffice, "offices") =>
     Offices.resolveSingleOffice(res, specificoffice)
 
-  | "parties" when Request.isMethod(req, "GET") =>
-    Parties.resolveAllParties(res)
+  | ("parties", "GET") => Parties.resolveAllParties(res)
 
-  | "parties" when Request.isMethod(req, "POST") =>
-    Parties.createParty(req, res)
+  | ("parties", "POST") => Parties.createParty(req, res)
 
-  | specificparty
-      when
-        Request.isMethod(req, "GET")
-        && Utils.isRouteDynamic(specificparty, "parties") =>
+  | (specificparty, "GET")
+      when Utils.isRouteDynamic(specificparty, "parties") =>
     Parties.resolveSingleParty(res, specificparty)
 
-  | updateparty
+  | (updateparty, "PATCH")
       when
-        Request.isMethod(req, "PATCH")
-        && Utils.isRouteDynamic(updateparty, "parties")
+        Utils.isRouteDynamic(updateparty, "parties")
         && Parties.isPartyUpdateRoute(updateparty) =>
     Parties.updateParty(req, res, updateparty)
 
-  | deleteparty
-      when
-        Request.isMethod(req, "DELETE")
-        && Utils.isRouteDynamic(deleteparty, "parties") =>
+  | (deleteparty, "DELETE") when Utils.isRouteDynamic(deleteparty, "parties") =>
     Parties.deleteParty(res, deleteparty)
   | route => Response.(res |> end_(route))
   };


### PR DESCRIPTION
**What does this PR do?**
This PR pattern matches on the HTTP method in conjunction with the path of the project. in a tuple format.
**Description of Task to be completed?**

<!-- Outline the tasks completed by the pr -->

- [x] Pattern match on the http method for more clarity on
the http method to be requested.

**How should this be manually tested?**

- Clone the repo
- Checkout on the `ch-pattern-match-on-httpmethod` 
- Compile the files via `yarn watch`
- Start the server via `node src/server.bs.js`
- Use the endpoints to see everything still works as expected.

**Any background context you want to provide?**
Pattern matching on the http method makes the code a bit more readable as the guard clauses don't have as many checks to do so there's less code in the clauses which makes it much more readable.
The pattern match instead of matching on a string now matches on a tuple of the route and the http method

***Before***
```re
  switch (path) {
  | "offices" when Request.isMethod(req, "GET") =>
    Offices.resolveAllOffices(res)
```

***Now***

```re
  switch (path, Request.method(req)) {
  | ("offices", "GET") => Offices.resolveAllOffices(res)
```

